### PR TITLE
add example without external context loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Automotive Solution Center for Simulation e.V.
 
 ## Credentials and Schemas
-A public repository containing examples for (verifiable) credentials and associated json schemas. The crendetials are used in the [Decentralized Digital Membership Management](https://ascs.digital).
+A public repository containing examples for (verifiable) credentials and associated json-ld context definitions. The crendetials are used in the [Decentralized Digital Membership Management](https://ascs.digital).
 The DID of issuers and subjects and the UUIDs of the credentials have been aligned with the content of the following example [revocation registry](https://better-call.dev/ghostnet/KT1PZFXebyGvRFG8enbuVL9nrvTi4krYqeKt/storage.)
+
+## Examples
+There are two types of json-ld examples for the credentials. The member credentials and the user credential. The member credential is used to e.g. register a company with an application like e.g. [Simpulse](https://simpulse.de) for creating the company profile with minimal validated information. The user credential is used in ascs applications to set initial rights and roles.
+The examples are once given with an external context definition and also with the attributes defined directly in the credential. This is necessary as third-party libraries like [didkit](https://github.com/spruceid/didkit) does not allow external context loading due to security implications.
 
 ## Resources
 

--- a/examples/member-credential-full.json
+++ b/examples/member-credential-full.json
@@ -1,0 +1,68 @@
+{
+    "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        {
+            "@version": 1.1,
+            "@protected": true,
+            "AscsMemberCredential": "https://schema.ascs.digital/AscsMemberCredential",
+            "AscsMember": {
+                "@id": "https://schema.ascs.digital/AscsMember",
+                "@context": {
+                    "@version": 1.1,
+                    "@protected": true,
+                    "name": "https://schema.org/name",
+                    "url": "https://schema.org/url",
+                    "address": "http://schema.org/address",
+                    "vatID": "http://schema.org/vatID",
+                    "isAscsMember": "http://schema.org/Boolean",
+                    "isEnvitedMember": "http://schema.org/Boolean",
+                    "privacyPolicy": "https://schema.org/termsOfService",
+                    "articlesOfAssociation": "https://schema.org/termsOfService",
+                    "contributionRules": "https://schema.org/termsOfService"
+                }
+            },
+            "PostalAddress": {
+                "@id": "http://schema.org/PostalAddress",
+                "@context": {
+                    "@version": 1.1,
+                    "@protected": true,
+                    "streetAddress": "http://schema.org/streetAddress",
+                    "postalCode": "http://schema.org/postalCode",
+                    "addressLocality": "http://schema.org/addressLocality",
+                    "addressCountry": "https://schema.org/addressCountry"
+                }
+            }
+        }
+    ],
+    "type": [
+        "VerifiableCredential",
+        "AscsMemberCredential"
+    ],
+    "issuanceDate": "2023-11-22T17:14:33Z",
+    "expirationDate": "2102-09-15T17:14:33Z",
+    "id": "urn:uuid:576fbefb-35e8-4b71-bb1a-53d1803c86de",
+    "issuer": {
+        "name": "Automotive Solution Center for Simulation e.V.",
+        "url": "https://asc-s.de/",
+        "id": "did:pkh:tz:tz1ggujjYjA7oYoaZBzTg1tYSXn3VMjcgDuv"
+    },
+    "credentialSubject": {
+        "id": "did:pkh:tz:tz1bpeJArd7apJyTUryfXH1SD6w8GL6Gwhj8",
+        "type": "AscsMember",
+        "name": "Testcompany GmbH",
+        "url": "https://test.de/",
+        "address": {
+            "type": "PostalAddress",
+            "streetAddress": "Teststraße 1",
+            "postalCode": "12345",
+            "addressLocality": "Munich",
+            "addressCountry": "DE"
+        },
+        "vatID": "DE123456789",
+        "isAscsMember": true,
+        "isEnvitedMember": true,
+        "privacyPolicy": "https://asc-s.de/datenschutz",
+        "articlesOfAssociation": "https://asc-s.de/media/files/ascs_articles_of_association_2021-09-17.pdf",
+        "contributionRules": "https://asc-s.de/media/files/ascs_Contribution_Rules_as_of_2020-07-08_YNCA2wi.pdf"
+    }
+}

--- a/examples/user-credential-full.json
+++ b/examples/user-credential-full.json
@@ -1,0 +1,62 @@
+{
+    "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        {
+            "@version": 1.1,
+            "@protected": true,
+            "AscsUserCredential": "https://schema.ascs.digital/AscsUserCredential",
+            "AscsUser": {
+                "@id": "https://schema.ascs.digital/AscsUser",
+                "@context": {
+                    "@version": 1.1,
+                    "@protected": true,
+                    "name": "https://schema.org/name",
+                    "email": "https://schema.org/email",
+                    "address": "http://schema.org/address",
+                    "isAscsMember": "http://schema.org/Boolean",
+                    "isEnvitedMember": "http://schema.org/Boolean",
+                    "privacyPolicy": "https://schema.org/termsOfService"
+                }
+            },
+            "PostalAddress": {
+                "@id": "http://schema.org/PostalAddress",
+                "@context": {
+                    "@version": 1.1,
+                    "@protected": true,
+                    "streetAddress": "http://schema.org/streetAddress",
+                    "postalCode": "http://schema.org/postalCode",
+                    "addressLocality": "http://schema.org/addressLocality",
+                    "addressCountry": "https://schema.org/addressCountry"
+                }
+            }
+        }
+    ],
+    "type": [
+        "VerifiableCredential",
+        "AscsUserCredential"
+    ],
+    "issuanceDate": "2023-11-22T17:14:33Z",
+    "expirationDate": "2102-09-15T17:14:33Z",
+    "id": "urn:uuid:cf1f329d-9c4c-458e-ba0a-a762a296b79c",
+    "issuer": {
+        "name": "Testcompany GmbH",
+        "url": "https://test.de/",
+        "id": "did:pkh:tz:tz1bpeJArd7apJyTUryfXH1SD6w8GL6Gwhj8"
+    },
+    "credentialSubject": {
+        "id": "did:pkh:tz:tz1SfdVU1mor3Sgej3FmmwMH4HM1EjTzqqeE",
+        "type": "AscsUser",
+        "name": "User",
+        "mail": "mailto:user@test.de",
+        "address": {
+            "type": "PostalAddress",
+            "streetAddress": "Teststraße 1",
+            "postalCode": "12345",
+            "addressLocality": "Munich",
+            "addressCountry": "DE"
+        },
+        "isAscsMember": true,
+        "isEnvitedMember": true,
+        "privacyPolicy": "https://asc-s.de/datenschutz"
+    }
+}


### PR DESCRIPTION
The examples are once given with an external context definition and also with the attributes defined directly in the credential. This is necessary as third-party libraries like [didkit](https://github.com/spruceid/didkit) does not allow external context loading due to security implications.