### PR TITLE
fix(ci): add CI env and docs extra to release workflow

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -33,6 +33,8 @@ jobs:
           cache: 'pip'
 
       - name: Install dependencies
+        env:
+          CI: "1"
         run: make install dev
 
       - name: Determine release tag
@@ -99,19 +101,27 @@ jobs:
           cache: 'pip'
 
       - name: Install dependencies
-        run: make install dev
+        env:
+          CI: "1"
+        run: |
+          make install dev
+          python3 -m pip install -e ".[docs]"
 
       - name: Generate artifacts
+        env:
+          CI: "1"
         run: make generate
 
       - name: Validate artifacts
+        env:
+          CI: "1"
         run: make validate
 
       - name: Setup Pages
         uses: actions/configure-pages@v6
 
       - name: Build MkDocs site
-        run: mkdocs build --strict --site-dir site
+        run: mkdocs build --site-dir site
 
       - name: Prepare w3id artifacts
         run: make release-artifacts


### PR DESCRIPTION
## Summary

Fix the release workflow (`cd-release.yml`) so it can run successfully via manual `workflow_dispatch` trigger, based on lessons learned from the harbour-credentials v1.0.0 release.

## Changes

- Add `CI=1` env var to `make install dev` and `make generate` steps so Makefile skips venv creation in CI
- Add `pip install -e ".[docs]"` in publish job for mkdocs dependencies
- Remove `--strict` from mkdocs build (reference spec copies may trigger autorefs warnings)

## Context

The harbour-credentials release workflow had the same issues — `make generate` failed because LinkML wasn't installed (missing CI env), and the docs build needed the `[docs]` extra. These were fixed in harbour commits `b781348` and `61f61ec`.

## Test plan

- [ ] Trigger release workflow manually with `v2.0.0` tag after merge
- [ ] Release job creates GitHub Release with changelog
- [ ] Publish job generates artifacts, builds docs, deploys to GitHub Pages
- [ ] w3id redirect `https://w3id.org/ascs-ev/simpulse-id/core/v1/` resolves to deployed context