### PR TITLE
docs: add ENVITED-X, EVES specifications, and harbour context

### DIFF
--- a/docs/credential-relationships.md
+++ b/docs/credential-relationships.md
@@ -3,6 +3,12 @@
 This document explains how the five SimpulseID credential types relate to each other,
 the entities they describe, and the semantic meaning of `member` vs `memberOf`.
 
+SimpulseID serves as the identity layer for the [ENVITED-X Data Space](https://staging.envited-x.net),
+operated by [ASCS e.V.](https://ascs.digital) at [identity.ascs.digital](https://identity.ascs.digital).
+The credential relationships are specified in [EVES-008 §2](https://github.com/ASCS-eV/EVES/blob/main/EVES/EVES-008/eves-008.md).
+All credentials are built on [harbour-credentials](https://github.com/reachhaven/harbour-credentials),
+which provides the Gaia-X compliance baseline via the `harbourCredential` IRI reference pattern.
+
 ## Entity Graph
 
 The ENVITED ecosystem has four kinds of entities and five credential types that

--- a/docs/credentials/administrator.md
+++ b/docs/credentials/administrator.md
@@ -1,6 +1,6 @@
 # AdministratorCredential
 
-The **AdministratorCredential** attests to a natural person with elevated permissions within the SimpulseID ecosystem. Administrators can manage organizational credentials, approve memberships, and perform privileged operations.
+The **AdministratorCredential** attests to a natural person with elevated permissions within the [ENVITED-X Data Space](https://staging.envited-x.net). Administrators can manage organizational credentials, approve memberships, and perform privileged operations. Issued by [ASCS e.V.](https://ascs.digital) at [identity.ascs.digital](https://identity.ascs.digital). Specified in [EVES-008 §2.2](https://github.com/ASCS-eV/EVES/blob/main/EVES/EVES-008/eves-008.md).
 
 ## Overview
 

--- a/docs/credentials/index.md
+++ b/docs/credentials/index.md
@@ -1,47 +1,62 @@
 # Credential Types
 
-This section documents the verifiable credential types defined in this repository.
+SimpulseID defines five W3C Verifiable Credential types for identity and membership management in the [ENVITED-X Data Space](https://staging.envited-x.net). All credentials are issued by [ASCS e.V.](https://ascs.digital) as the trust anchor, deployed at [identity.ascs.digital](https://identity.ascs.digital).
+
+Each credential type extends `HarbourCredential` from the [harbour-credentials](https://github.com/reachhaven/harbour-credentials) base schema. Credential subjects carry a mandatory `harbourCredential` IRI linking to a Harbour Gaia-X compliance credential, which provides the baseline of trust (Gaia-X `LegalPerson` or `NaturalPerson` attestation).
+
+The credential types and their lifecycle are specified in [EVES-008](https://github.com/ASCS-eV/EVES/blob/main/EVES/EVES-008/eves-008.md). Evidence VPs follow [EVES-009](https://github.com/ASCS-eV/EVES/blob/main/EVES/EVES-009/eves-009.md).
 
 ## Available Types
 
-| Credential Type | Description | Schema |
-|-----------------|-------------|--------|
-| [ParticipantCredential](participant.md) | Organization/company identity | `simpulseid:ParticipantCredential` |
-| [UserCredential](user.md) | Individual user identity | `simpulseid:UserCredential` |
-| [AdministratorCredential](administrator.md) | Admin role attestation | `simpulseid:AdministratorCredential` |
-| [Membership Credentials](membership.md) | ASCS membership programs | `simpulseid:AscsBaseMembershipCredential`, `simpulseid:AscsEnvitedMembershipCredential` |
+| Credential Type | Description | Subject ID | Schema |
+|-----------------|-------------|------------|--------|
+| [ParticipantCredential](participant.md) | Organization identity (gx:LegalPerson) | `did:ethr` | `simpulseid:ParticipantCredential` |
+| [AdministratorCredential](administrator.md) | Elevated-permission natural person | `did:ethr` | `simpulseid:AdministratorCredential` |
+| [UserCredential](user.md) | Standard natural person | `did:ethr` | `simpulseid:UserCredential` |
+| [Base Membership](membership.md) | ASCS e.V. base membership | `urn:uuid:` | `simpulseid:AscsBaseMembershipCredential` |
+| [ENVITED Membership](membership.md) | ENVITED research cluster membership | `urn:uuid:` | `simpulseid:AscsEnvitedMembershipCredential` |
+
+## Issuance Order (per EVES-008 §2)
+
+Credentials MUST be issued in the following order:
+
+1. **ParticipantCredential** --- ASCS verifies the organization's legal identity
+2. **AscsBaseMembershipCredential** --- requires ParticipantCredential as prerequisite
+3. **AscsEnvitedMembershipCredential** (optional) --- requires BaseMembership as prerequisite
+4. **AdministratorCredential** / **UserCredential** --- issued to natural persons under a participant
 
 ## Schema Structure
 
-All credentials follow the W3C Verifiable Credentials Data Model v2.0:
+All credentials follow the W3C Verifiable Credentials Data Model v2.0 with three mandatory `@context` entries:
 
 ```json
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
-    "<domain-context>"
+    "https://w3id.org/reachhaven/harbour/core/v1/",
+    "https://w3id.org/ascs-ev/simpulse-id/v1/"
   ],
   "type": ["VerifiableCredential", "<credential-type>"],
-  "issuer": "<did>",
+  "issuer": "<issuer-did>",
   "validFrom": "<iso-datetime>",
   "credentialSubject": {
-    "id": "<subject-did>",
-    // type-specific claims
-  }
+    "id": "<subject-did-or-urn>",
+    "type": "<subject-type>",
+    "harbourCredential": "<harbour-gx-credential-urn>"
+  },
+  "credentialStatus": [{"type": "harbour:CRSetEntry", "statusPurpose": "revocation"}],
+  "evidence": [{"type": ["harbour:CredentialEvidence"], "verifiablePresentation": "..."}]
 }
 ```
 
 ## LinkML Definitions
 
-Credential types are defined in LinkML YAML files under `linkml/`:
+Credential types are defined in a single LinkML schema:
 
-- `linkml/simpulseid-core.yaml` — Subject types (Participant, Administrator, User, Memberships)
-- `linkml/simpulseid-credentials.yaml` — Credential type definitions (is_a: HarbourCredential)
-- `linkml/importmap.json` — Import resolution for harbour-credentials and Gaia-X schemas
+- `linkml/simpulseid-core.yaml` --- All subject types, credential types, program metadata, and enums
+- `linkml/importmap.json` --- Import resolution for harbour-credentials and Gaia-X schemas
 
-## Generating Artifacts
-
-After modifying LinkML schemas, regenerate artifacts:
+After modifying schemas, regenerate artifacts:
 
 ```bash
 make generate

--- a/docs/credentials/participant.md
+++ b/docs/credentials/participant.md
@@ -1,6 +1,6 @@
 # ParticipantCredential
 
-The **ParticipantCredential** attests to an organization's identity within the SimpulseID ecosystem. It is the foundational credential for legal entities such as companies, research institutions, or associations.
+The **ParticipantCredential** attests to an organization's identity within the [ENVITED-X Data Space](https://staging.envited-x.net). It is the foundational credential for legal entities such as companies, research institutions, or associations. Issued by [ASCS e.V.](https://ascs.digital) as the trust anchor, deployed at [identity.ascs.digital](https://identity.ascs.digital). Specified in [EVES-008 §2.1](https://github.com/ASCS-eV/EVES/blob/main/EVES/EVES-008/eves-008.md).
 
 ## Overview
 

--- a/docs/credentials/user.md
+++ b/docs/credentials/user.md
@@ -1,6 +1,6 @@
 # UserCredential
 
-The **UserCredential** attests to a natural person's identity within the SimpulseID ecosystem. It is used for standard users such as employees, researchers, or individual participants.
+The **UserCredential** attests to a natural person's identity within the [ENVITED-X Data Space](https://staging.envited-x.net). It is used for standard users such as employees, researchers, or individual participants. Issued by [ASCS e.V.](https://ascs.digital) at [identity.ascs.digital](https://identity.ascs.digital). Specified in [EVES-008 §2.3](https://github.com/ASCS-eV/EVES/blob/main/EVES/EVES-008/eves-008.md).
 
 ## Overview
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,33 +1,61 @@
-# Credentials Documentation
+# SimpulseID Credentials
 
-Welcome to the **Credentials** repository documentation. This repository contains verifiable credential schemas and artifacts for the ENVITED-X ecosystem.
+SimpulseID is the credential and identity framework for the **ENVITED-X Data Space**, operated by the [Automotive Solution Center for Simulation e.V. (ASCS e.V.)](https://ascs.digital). It is deployed at [identity.ascs.digital](https://identity.ascs.digital).
 
-## Overview
+SimpulseID enables verifiable onboarding of organizations and users, program membership verification, and secure authentication across ENVITED-X services using W3C Verifiable Credentials v2 and `did:ethr` identifiers.
 
-This repository provides:
+## Architecture
 
-- **LinkML Schemas** — Credential type definitions in LinkML format
-- **Generated Artifacts** — OWL ontologies, SHACL shapes, JSON-LD contexts
-- **Example Credentials** — Sample verifiable credentials for testing
-- **Validation Tools** — SHACL validation via ontology-management-base
+SimpulseID is built as a **domain layer on top of [harbour-credentials](https://github.com/reachhaven/harbour-credentials)** (by [Haven](https://www.reachhaven.com)). Harbour provides the ecosystem-agnostic cryptographic infrastructure (signing, verification, SD-JWT, delegation), while SimpulseID adds ENVITED-specific credential types, membership chains, and Gaia-X Trust Framework alignment.
+
+```text
++------------------------------------------------------+
+|  SimpulseID (this repo)                              |
+|  - 5 credential types + subject schemas              |
+|  - Membership chains, program metadata               |
+|  - ENVITED-X governance (ASCS e.V.)                  |
++------------------------------------------------------+
+|  Harbour Credentials (submodule)                     |
+|  - W3C VC v2 base types (HarbourCredential, CRSet)   |
+|  - Gaia-X LegalPerson / NaturalPerson composition    |
+|  - JOSE signing, SD-JWT-VC, delegation evidence      |
+|  - did:ethr key management                           |
++------------------------------------------------------+
+```
+
+Each SimpulseID credential subject carries a mandatory `harbourCredential` IRI linking to a Harbour Gaia-X compliance credential, which serves as the baseline of trust.
+
+## Specifications
+
+This repository is the reference implementation of two ENVITED-X Ecosystem Specifications (EVES):
+
+- **[EVES-008](https://github.com/ASCS-eV/EVES/blob/main/EVES/EVES-008/eves-008.md)** --- SimpulseID Credential and Identity Framework
+- **[EVES-009](https://github.com/ASCS-eV/EVES/blob/main/EVES/EVES-009/eves-009.md)** --- Evidence-Based Consent Using Verifiable Presentations
+
+See the [Specifications](specifications.md) page for details and external standards.
+
+## Credential Types
+
+All credentials are issued by ASCS e.V. as the trust anchor for the ENVITED-X Data Space.
+
+| Type | Description | Issuer |
+|------|-------------|--------|
+| [ParticipantCredential](credentials/participant.md) | Organization identity (gx:LegalPerson) | ASCS e.V. |
+| [AdministratorCredential](credentials/administrator.md) | Elevated-permission natural person | ASCS e.V. |
+| [UserCredential](credentials/user.md) | Standard natural person | ASCS e.V. |
+| [Base Membership](credentials/membership.md) | ASCS e.V. base membership | ASCS e.V. |
+| [ENVITED Membership](credentials/membership.md) | ENVITED research cluster membership | ASCS e.V. |
 
 ## Quick Links
 
 - [Installation](getting-started/installation.md)
 - [Quick Start](getting-started/quickstart.md)
-- [Credential Types](credentials/index.md)
+- [Credential Relationships](credential-relationships.md)
 - [Examples](examples/index.md)
-
-## Credential Types
-
-| Type | Description |
-|------|-------------|
-| [ParticipantCredential](credentials/participant.md) | Organization/company credentials |
-| [UserCredential](credentials/user.md) | Individual user credentials |
-| [AdministratorCredential](credentials/administrator.md) | Admin role credentials |
-| [Membership Credentials](credentials/membership.md) | ASCS base and ENVITED membership attestations |
+- [Specifications](specifications.md)
 
 ## Related Projects
 
-- [harbour-credentials](https://github.com/ASCS-eV/harbour-credentials) — Cryptographic signing library
-- [ontology-management-base](https://github.com/ASCS-eV/ontology-management-base) — Validation pipeline
+- [harbour-credentials](https://github.com/reachhaven/harbour-credentials) --- Cryptographic signing library (by Haven)
+- [ontology-management-base](https://github.com/ASCS-eV/ontology-management-base) --- SHACL validation pipeline
+- [EVES](https://github.com/ASCS-eV/EVES) --- ENVITED-X Ecosystem Specifications

--- a/docs/integration/harbour.md
+++ b/docs/integration/harbour.md
@@ -69,7 +69,7 @@ evidence_vp_jwt = sign_vp_jose(
 )
 ```
 
-The nonce is computed as a SHA-256 hash of the issuer's payload, binding the evidence to the specific credential issuance per [OID4VP §8.4](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html).
+The nonce uses the `HARBOUR_DELEGATE` challenge format from harbour's delegation module, binding the evidence to the specific credential issuance. The challenge is `<random> HARBOUR_DELEGATE <SHA-256(TransactionData)>` with the `credential.issue` action type. This follows [EVES-009](https://github.com/ASCS-eV/EVES/blob/main/EVES/EVES-009/eves-009.md) and [OID4VP §8.4](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html).
 
 ## SD-JWT-VC Structured Selective Disclosure
 

--- a/docs/reference/credential-model.md
+++ b/docs/reference/credential-model.md
@@ -1,8 +1,9 @@
 # Credential Data Model
 
 This page documents how SimpulseID credential types extend the
-[Harbour Credentials](https://ascs-ev.github.io/harbour-credentials/schema/credential-model/)
-base model. For the base class hierarchy and Gaia-X composition pattern,
+[Harbour Credentials](https://reachhaven.github.io/harbour-credentials/schema/credential-model/)
+base model, as specified in [EVES-008 §3.3](https://github.com/ASCS-eV/EVES/blob/main/EVES/EVES-008/eves-008.md).
+For the base class hierarchy and Gaia-X composition pattern,
 see the harbour-credentials documentation.
 
 ## Schema File Structure

--- a/docs/specifications.md
+++ b/docs/specifications.md
@@ -1,0 +1,40 @@
+# Specifications
+
+SimpulseID implements the following ENVITED-X Ecosystem Specifications (EVES), maintained at [github.com/ASCS-eV/EVES](https://github.com/ASCS-eV/EVES).
+
+## EVES-008: SimpulseID Credential and Identity Framework
+
+[EVES-008](https://github.com/ASCS-eV/EVES/blob/main/EVES/EVES-008/eves-008.md) defines the identity, membership, and credential architecture for the ENVITED-X Data Space. It specifies:
+
+- Five credential types (Participant, Administrator, User, Base Membership, ENVITED Membership)
+- `did:ethr` identifiers anchored on Base (ERC-1056) with P-256 key management
+- JSON-LD context ordering and `w3id.org` persistent identifier resolution
+- Credential subject semantics (`member` vs `memberOf`, `urn:uuid:` for memberships)
+- Revocation via `harbour:CRSetEntry`
+- Schema-first approach using LinkML as the single source of truth
+
+This repository is the reference implementation of EVES-008.
+
+## EVES-009: Evidence-Based Consent Using Verifiable Presentations
+
+[EVES-009](https://github.com/ASCS-eV/EVES/blob/main/EVES/EVES-009/eves-009.md) defines the protocol for generating and verifying cryptographic evidence of user consent. SimpulseID credentials use this protocol for evidence VPs:
+
+- Evidence VPs use the `HARBOUR_DELEGATE` challenge format with the `credential.issue` action type
+- The challenge binds consent to a specific credential via SHA-256 over canonical `TransactionData`
+- Verification follows OID4VP with KB-JWT `transaction_data_hashes` for message binding
+- SD-JWT VCs are the recommended format for selective disclosure
+
+The evidence protocol is implemented by [harbour-credentials](https://github.com/reachhaven/harbour-credentials) (`delegation.py`, `sd_jwt_vp.py`). SimpulseID uses it via `src/sign_examples.py`.
+
+## External Standards
+
+| Standard | Version | Usage |
+|----------|---------|-------|
+| [W3C VC Data Model](https://www.w3.org/TR/vc-data-model-2.0/) | v2.0 | Credential envelope structure |
+| [W3C DID Core](https://www.w3.org/TR/did-core/) | v1.1 | Decentralized identifier resolution |
+| [did:ethr Method](https://github.com/decentralized-identity/ethr-did-resolver/blob/master/doc/did-method-spec.md) | — | On-chain identity via ERC-1056 |
+| [Gaia-X Trust Framework](https://docs.gaia-x.eu/) | 25.11 (Loire) | LegalPerson/NaturalPerson compliance |
+| [OID4VP](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html) | 1.0 | Evidence VP presentation protocol |
+| [RFC 9901 (SD-JWT-VC)](https://www.rfc-editor.org/rfc/rfc9901) | — | Selective disclosure credentials |
+| [LinkML](https://linkml.io/) | — | Schema definition language |
+| [schema.org](https://schema.org/) | — | Vocabulary for program metadata |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
-site_name: Credentials Documentation
-site_description: Verifiable credential schemas and artifacts for the ENVITED-X ecosystem
-site_url: https://ascs-ev.github.io/credentials/
-repo_url: https://github.com/ASCS-eV/credentials
-repo_name: ASCS-eV/credentials
+site_name: SimpulseID Credentials
+site_description: Credential and identity framework for the ENVITED-X Data Space
+site_url: https://ascs-ev.github.io/simpulse-id-credentials/
+repo_url: https://github.com/ASCS-eV/simpulse-id-credentials
+repo_name: ASCS-eV/simpulse-id-credentials
 
 theme:
   name: material
@@ -53,6 +53,7 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Specifications: specifications.md
   - Getting Started:
       - Installation: getting-started/installation.md
       - Quick Start: getting-started/quickstart.md
@@ -62,6 +63,9 @@ nav:
       - User: credentials/user.md
       - Administrator: credentials/administrator.md
       - Membership: credentials/membership.md
+  - Architecture:
+      - Credential Relationships: credential-relationships.md
+      - DID Methods: did-methods.md
   - Examples:
       - Gallery: examples/index.md
   - Integration:


### PR DESCRIPTION
## Summary

Add missing contextual information throughout the documentation. The audit found that EVES-008/009 specifications, the ENVITED-X Data Space context, ASCS e.V. operator attribution, identity.ascs.digital deployment, and the harbour-credentials architecture relationship were missing from most documentation pages.

## Changes

### New file
- **`docs/specifications.md`** --- Dedicated page citing EVES-008 (SimpulseID Framework) and EVES-009 (Evidence-Based Consent) with external standards table (W3C VC, DID Core, Gaia-X, OID4VP, RFC 9901, LinkML)

### Rewritten files
- **`docs/index.md`** --- ENVITED-X Data Space introduction, harbour-credentials architecture diagram, EVES spec references, ASCS e.V. as trust anchor, credential type table with issuer column
- **`docs/credentials/index.md`** --- EVES-008 issuance order (§2), harbourCredential IRI explanation, identity.ascs.digital deployment, corrected @context array with all three mandatory entries

### Updated files
- **`docs/credentials/participant.md`** --- Added ENVITED-X context, ASCS e.V. issuer, identity.ascs.digital, EVES-008 §2.1 reference
- **`docs/credentials/administrator.md`** --- Same: EVES-008 §2.2 reference
- **`docs/credentials/user.md`** --- Same: EVES-008 §2.3 reference
- **`docs/credential-relationships.md`** --- Added ENVITED-X context paragraph, harbour-credentials relationship, EVES-008 §2 citation
- **`docs/integration/harbour.md`** --- Updated evidence nonce description to reference HARBOUR_DELEGATE format and EVES-009
- **`docs/reference/credential-model.md`** --- Added EVES-008 §3.3 citation, fixed harbour docs URL
- **`mkdocs.yml`** --- Updated site name/URL to "SimpulseID Credentials" / simpulse-id-credentials, added Specifications and Architecture nav sections

## Test plan

- [ ] `mkdocs build` succeeds locally
- [ ] All internal links resolve
- [ ] EVES-008/009 GitHub links are valid
- [ ] identity.ascs.digital links are valid