### PR TITLE
fix(ci): create tag before git-cliff in workflow_dispatch releases

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -51,6 +51,17 @@ jobs:
           fi
           echo "tag=$TAG" >> $GITHUB_OUTPUT
 
+      - name: Ensure tag exists for changelog generation
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+            git tag "$TAG"
+            echo "Created lightweight tag $TAG at $(git rev-parse HEAD)"
+          else
+            echo "Tag $TAG already exists"
+          fi
+
       - name: Generate changelog
         id: changelog
         uses: orhun/git-cliff-action@v4
@@ -60,7 +71,6 @@ jobs:
         env:
           OUTPUT: CHANGELOG.md
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3


### PR DESCRIPTION
## Summary

Port the release changelog fix from harbour-credentials to simpulse-id-credentials.

## Changes

- Add "Ensure tag exists for changelog generation" step to `cd-release.yml` before the git-cliff action
- Remove `continue-on-error: true` from the changelog step so failures are visible

## Context

When the release workflow is triggered via `workflow_dispatch`, the target tag does not yet exist in git history. `git-cliff --latest` then picks up the previous tag and generates an incorrect changelog (or fails silently due to `continue-on-error`).

This is the same bug that was fixed in harbour-credentials (`2c73d30`).

## Testing

- [ ] Workflow YAML is valid
- [ ] Tag push trigger still works (tag already exists → no-op)
- [ ] `workflow_dispatch` trigger creates lightweight tag before changelog generation

## Related

- harbour-credentials fix: `2c73d30` (`fix(ci): create tag before git-cliff in workflow_dispatch releases`)
